### PR TITLE
Allow for capitalized characters in paths tokens

### DIFF
--- a/src/ejsonpath_scan.xrl
+++ b/src/ejsonpath_scan.xrl
@@ -12,7 +12,7 @@ Rules.
 \] : {token, {']', TokenLine}}.
 \. : {token, {'.', TokenLine}}.
 
-[a-z][a-z0-9_]* : {token, {key, TokenLine, list_to_binary(TokenChars)}}.
+[a-zA-Z][a-zA-Z0-9_]* : {token, {key, TokenLine, list_to_binary(TokenChars)}}.
 [0-9]+ : {token, {int, TokenLine, list_to_integer(TokenChars)}}.
 
 %% indexing

--- a/test/doc.json
+++ b/test/doc.json
@@ -26,6 +26,11 @@
     "bicycle": {
       "color": "red",
       "price": 19.95
+    },
+    "LOLs": {
+      "Cats": "yes",
+      "Dogs": "yes",
+      "CHEEZBURG": "no"
     }
   }
 }

--- a/test/ejsonpath_tests.erl
+++ b/test/ejsonpath_tests.erl
@@ -9,7 +9,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-
 all_test_() ->
     Doc = get_doc(),
     Pairs = [
@@ -86,9 +85,13 @@ all_test_() ->
                 end}]},
 
              {"Index-eval on array",
-             "$.store.book[(1)].author", [<<"Evelyn Waugh">>]},
+              "$.store.book[(1)].author", [<<"Evelyn Waugh">>]},
              {"Index-eval on hash",
-             "$.store.book[(1)][('author')]", [<<"Evelyn Waugh">>]}
+              "$.store.book[(1)][('author')]", [<<"Evelyn Waugh">>]},
+             {"Capitals should work in paths",
+              "$.store.LOLs.CHEEZBURG", [<<"no">>]},
+             {"Capitals should work in paths",
+              "$.store.LOLs.Cats", [<<"yes">>]}
 
             ],
     lists:map(
@@ -114,24 +117,28 @@ get_doc() ->
     %% io:format(user, "~p~n", [jiffy:decode(Bin)]),
     %% jiffy:decode(Bin)
     {[{<<"store">>,
-       {[{<<"book">>,
-          [{[{<<"category">>,<<"reference">>},
-             {<<"author">>,<<"Nigel Rees">>},
-             {<<"title">>,<<"Sayings of the Century">>},
-             {<<"price">>,8.95}]},
-           {[{<<"category">>,<<"fiction">>},
-             {<<"author">>,<<"Evelyn Waugh">>},
-             {<<"title">>,<<"Sword of Honour">>},
-             {<<"price">>,12.99}]},
-           {[{<<"category">>,<<"fiction">>},
-             {<<"author">>,<<"Herman Melville">>},
-             {<<"title">>,<<"Moby Dick">>},
-             {<<"isbn">>,<<"0-553-21311-3">>},
-             {<<"price">>,8.99}]},
-           {[{<<"category">>,<<"fiction">>},
-             {<<"author">>,<<"J. R. R. Tolkien">>},
-             {<<"title">>,<<"The Lord of the Rings">>},
-             {<<"isbn">>,<<"0-395-19395-8">>},
-             {<<"price">>,22.99}]}]},
-         {<<"bicycle">>,{[{<<"color">>,<<"red">>},
-                          {<<"price">>,19.95}]}}]}}]}.
+          {[{<<"book">>,
+                [{[{<<"category">>,<<"reference">>},
+                      {<<"author">>,<<"Nigel Rees">>},
+                      {<<"title">>,<<"Sayings of the Century">>},
+                      {<<"price">>,8.95}]},
+                  {[{<<"category">>,<<"fiction">>},
+                      {<<"author">>,<<"Evelyn Waugh">>},
+                      {<<"title">>,<<"Sword of Honour">>},
+                      {<<"price">>,12.99}]},
+                  {[{<<"category">>,<<"fiction">>},
+                      {<<"author">>,<<"Herman Melville">>},
+                      {<<"title">>,<<"Moby Dick">>},
+                      {<<"isbn">>,<<"0-553-21311-3">>},
+                      {<<"price">>,8.99}]},
+                  {[{<<"category">>,<<"fiction">>},
+                      {<<"author">>,<<"J. R. R. Tolkien">>},
+                      {<<"title">>,<<"The Lord of the Rings">>},
+                      {<<"isbn">>,<<"0-395-19395-8">>},
+                      {<<"price">>,22.99}]}]},
+              {<<"bicycle">>,
+                {[{<<"color">>,<<"red">>},{<<"price">>,19.95}]}},
+              {<<"LOLs">>,
+                {[{<<"Cats">>,<<"yes">>},
+                    {<<"Dogs">>,<<"yes">>},
+                    {<<"CHEEZBURG">>,<<"no">>}]}}]}}]}.


### PR DESCRIPTION
The online evaluator uses mixed case which didn't work with ejsonpath, so I added the uppercase variables to the lexer as well as the test cases.
