### PR TITLE
Implement simple binary ops

### DIFF
--- a/src/ejsonpath_parse.yrl
+++ b/src/ejsonpath_parse.yrl
@@ -61,11 +61,14 @@ function_call function_args function_argument.
 Terminals
 '$' '..' '@' '[' ']' '.' key int
 '*' ',' ':'
-'?' '(' ')' string '==' '&&' '+' '-' '/'.
+'?' '(' ')' string '==' '!=' '<' '>' '&&' '+' '-' '/'.
 
 Rootsymbol expr.
 
 Nonassoc 200 '=='.
+Nonassoc 200 '!='.
+Nonassoc 200 '<'.
+Nonassoc 200 '>'.
 Left 300 '+'.
 Left 300 '-'.
 Left 400 '/'.
@@ -117,10 +120,14 @@ function_argument -> sint : value('$1').
 
 operand -> string : value('$1').
 operand -> '@' : value('$1').
+operand -> '@' steps : '$2'.
 operand -> int : value('$1').
 %% operand -> expr.
 
 bin_operator -> '==' : value('$1').
+bin_operator -> '!=' : value('$1').
+bin_operator -> '>' : value('$1').
+bin_operator -> '<' : value('$1').
 bin_operator -> '&&' : value('$1').
 bin_operator -> '+' : value('$1').
 bin_operator -> '-' : value('$1').

--- a/src/ejsonpath_scan.xrl
+++ b/src/ejsonpath_scan.xrl
@@ -29,6 +29,9 @@ Rules.
 \'[^']*\' : {token, {string, TokenLine, list_to_binary(string:substr(TokenChars, 2, TokenLen - 2))}}.
 
 == : {token, {'==', TokenLine}}.
+!= : {token, {'!=', TokenLine}}.
+< : {token, {'<', TokenLine}}.
+> : {token, {'>', TokenLine}}.
 && : {token, {'&&', TokenLine}}.
 \+ : {token, {'+', TokenLine}}.
 \- : {token, {'-', TokenLine}}.

--- a/test/ejsonpath_tests.erl
+++ b/test/ejsonpath_tests.erl
@@ -84,6 +84,23 @@ all_test_() ->
                         end
                 end}]},
 
+             {"Script simple path",
+              "$.store.book[?(@.isbn)].price", [8.99, 22.99]},
+             {"Script greater than expr",
+              "$.store.book[?(@.price > 9)].isbn", [<<"0-395-19395-8">>]},
+             {"Script equality expr",
+              "$.store.book[?('reference' == @.category)].author",
+              [<<"Nigel Rees">>]},
+             {"Script inequality expr",
+              "$.store.book[?(@.category != 'fiction')].author",
+              [<<"Nigel Rees">>]},
+             {"Script comparing constants",
+              "$.store.book[?('asdf'=='asdf')].category",
+              [<<"reference">>, <<"fiction">>, <<"fiction">>, <<"fiction">>]},
+             {"Script comparing paths",
+              "$.store.book[?(@.category == @.category)].category",
+              [<<"reference">>, <<"fiction">>, <<"fiction">>, <<"fiction">>]},
+
              {"Index-eval on array",
               "$.store.book[(1)].author", [<<"Evelyn Waugh">>]},
              {"Index-eval on hash",


### PR DESCRIPTION
Hi Островок,

This patch implements `==`, `!=`, `<` and `>` binary ops. As a side effect it covers expressions checking for presence of a given key, e.g. `"$.store.book[?(@.isbn)]"` returning all books with an ISBN.

Let me know what you think.

Thanks!