### PR TITLE
Add maps support (in json objects and 'functions' argument)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build/
 deps/
 ebin/
 .eunit/

--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@ eJSONPath - jsonpath for erlang
 ===============================
 
 eJSONPath is pure-erlang implementation of [JSONPath](http://goessner.net/articles/JsonPath/).
-It uses jiffy JSON structure (`{[ {key(), value()}, ...]}` for structs) and implements most of the
-JSONPath description (I don't say specification, because there is no such thing like jsonpath spec).
+It supports both `map()` and jiffy JSON structure (`{[ {key(), value()}, ...]}` for kv-objects)
+and implements most of the JSONPath description (I don't say specification, because there is no
+such thing like jsonpath spec).
 
 * Robust extensible parser (leex + yecc).
 * Extensible by custom functions.
-* No dependencies (but you may want jiffy as json parser).
+* No dependencies (but you may want jiffy or any other json parser).
 
 Examples
 --------
 
 ```erlang
 {ok, Bin} = file:read_file("test/doc.json").
-Doc = jiffy:decode(Bin).
+Doc = jiffy:decode(Bin, [return_maps]).
 
 %% return 1'st book author
 [<<"Nigel Rees">>] = ejsonpath:execute("$.store.book[0].author", Doc).
@@ -24,16 +25,16 @@ Doc = jiffy:decode(Bin).
  <<"Nigel Rees">>] = ejsonpath:execute("$.store.book[0]['category','author']", Doc).
 
 %% return only reference book authors
-%% `Funs' is a list of `{Name, Fun}' pairs (see Fun spec on sources)
-Funs = [
-{<<"filter_category">>,
- fun({{Pairs}, _Doc}, [CategoryName]) ->
-     case proplists:get_value(<<"category">>, Pairs) of
-         CategoryName -> true;
+%% `Funs' is a map or propist of `Name` and `Fun` pairs (see Fun spec in the sources)
+Funs = #{
+ <<"filter_category">> =>
+  fun({Map, _Doc}, [CategoryName]) ->
+     case maps:find(<<"category">>, Map) of
+         {ok, CategoryName} -> true;
          _ -> false
      end
- end}
-],
+  end
+},
 [<<"Nigel Rees">>] = ejsonpath:execute(
                      "$.store.book[?(filter_category('reference'))].author", Doc, Funs).
 ```
@@ -47,30 +48,31 @@ it's own variations. But I try to follow description from [JSONPath](http://goes
 as close as possible.
 
 ```
-+-----------------------+---------------------+-----------+
-| Feature               | Example             |Implemented|
-+-----------------------+---------------------+-----------+
-|Dot filtering          |`$.one.two`          | Y         |
-+-----------------------+---------------------+-----------+
-|Brace filtering        |`$['one']['two']`    | Y         |
-+-----------------------+---------------------+-----------+
-|Array slicing          | `$[1,2,3]` `$.o[2]` | Y         |
-+-----------------------+---------------------+-----------+
-|Hash slicing           | `$['one', 'two']`   | Y         |
-+-----------------------+---------------------+-----------+
-|Asterisk (hash, array) | `$.one.*` `$.one[*]`| Y         |
-+-----------------------+---------------------+-----------+
-|Python-slicing         | `$[1:-1:2]`         | Partial*  |
-+-----------------------+---------------------+-----------+
-|Eval binary filter     | `$[?(true)]`        | Partial** |
-+-----------------------+---------------------+-----------+
-|Eval index             | `$[('one')]`        | Partial** |
-+-----------------------+---------------------+-----------+
-|Recursive descent      | `..`                | N         |
-+-----------------------+---------------------+-----------+
++-----------------------+------------------------+-----------+
+| Feature               | Example                |Implemented|
++-----------------------+------------------------+-----------+
+|Dot filtering          |`$.one.two`             | Y         |
++-----------------------+------------------------+-----------+
+|Brace filtering        |`$['one']['two']`       | Y         |
++-----------------------+------------------------+-----------+
+|Array slicing          | `$[1,2,3]` `$.o[2]`    | Y         |
++-----------------------+------------------------+-----------+
+|Hash slicing           | `$['one', 'two']`      | Y         |
++-----------------------+------------------------+-----------+
+|Asterisk (hash, array) | `$.one.*` `$.one[*]`   | Y         |
++-----------------------+------------------------+-----------+
+|Python-slicing         | `$[1:-1:2]`            | Partial*  |
++-----------------------+------------------------+-----------+
+|Eval binary filter     | `$[?(true)]`           | Partial** |
+|                       | `$[?(@.cat != 'mew')]` |           |
++-----------------------+------------------------+-----------+
+|Eval index             | `$[('one')]`           | Partial** |
++-----------------------+------------------------+-----------+
+|Recursive descent      | `..`                   | N         |
++-----------------------+------------------------+-----------+
 
 * Only step=1 supported now
-** Very limited scripting language: string, integer and function calls
+** Limited scripting language: string, integer, binary operators and function calls
 ```
 
 Most of the missing features can be implemented as custom functions
@@ -87,8 +89,6 @@ TODO
  * Python slicing step support. (Currently only step==1 supported)
  * Recursive descent (supported by parser, need evaluator)
  * Eval filter / index - allow path expressions and operators `$[?(@.category)]`
- * Eval filter / index - allow binary operators `$[?(@.category!='reference')]`
-* Support for alternative JSON representations (mochijson2, EEP-18)
 
 Other implementations
 ---------------------

--- a/src/ejsonpath.app.src
+++ b/src/ejsonpath.app.src
@@ -2,11 +2,13 @@
 {application, ejsonpath,
  [
   {description, "JSONPath for erlang"},
-  {vsn, "0.0.1"},
+  {vsn, "0.1.0"},
   {registered, []},
   {applications, [
                   kernel,
                   stdlib
                  ]},
-  {env, []}
+  {env, []},
+  {licenses, ["Apache 2.0"]},
+  {links, [{"GitHub", "https://github.com/ostrovok-team/ejsonpath"}]}
  ]}.

--- a/test/ejsonpath_tests.erl
+++ b/test/ejsonpath_tests.erl
@@ -9,108 +9,120 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all_test_() ->
-    Doc = get_doc(),
-    Pairs = [
-             {"Name refine dot",
-              "$.store.bicycle.color", [<<"red">>]},
-             {"Name refine bracket",
-              "$['store']['bicycle']['color']", [<<"red">>]},
+cases() ->
+    [
+     {"Name refine dot",
+      "$.store.bicycle.color", [<<"red">>]},
+     {"Name refine bracket",
+      "$['store']['bicycle']['color']", [<<"red">>]},
 
-             {"Array idx",
-              "$.store.book[0].category", [<<"reference">>]},
-             {"Array slice list",
-              "$.store.book[0,-1].author", [<<"Nigel Rees">>,
-                                            <<"J. R. R. Tolkien">>]},
+     {"Array idx",
+      "$.store.book[0].category", [<<"reference">>]},
+     {"Array slice list",
+      "$.store.book[0,-1].author", [<<"Nigel Rees">>, <<"J. R. R. Tolkien">>]},
 
-             {"Array slice python",
-              "$.store.book[0:2].price", [8.95, 12.99]},
-             {"Array slice python default begin",
-              "$.store.book[:2].price", [8.95, 12.99]},
-             {"Array slice python default end",
-              "$.store.book[2:].price", [8.99, 22.99]},
-             %% {"Array slice python minus begin",
-             %%  "$.store.book[-2:].price", [8.99, 22.99]},
-             {"Array slice python minus end",
-              "$.store.book[:-2].price", [8.95, 12.99]},
+     {"Array slice python",
+      "$.store.book[0:2].price", [8.95, 12.99]},
+     {"Array slice python default begin",
+      "$.store.book[:2].price", [8.95, 12.99]},
+     {"Array slice python default end",
+      "$.store.book[2:].price", [8.99, 22.99]},
+     %% {"Array slice python minus begin",
+     %%  "$.store.book[-2:].price", [8.99, 22.99]},
+     {"Array slice python minus end",
+      "$.store.book[:-2].price", [8.95, 12.99]},
 
-             {"Name refine bracket plus idx",
-              "$.store['book'][0].category", [<<"reference">>]},
-             {"Array idx",
-              "$.store.book[0].category", [<<"reference">>]},
-             {"Asterisk array",
-              "$.store.book[*].category", [<<"reference">>,
-                                           <<"fiction">>,
-                                           <<"fiction">>,
-                                           <<"fiction">>]},
-             {"Asterisk hash",
-              "$.store.bicycle[*]", [<<"red">>,
-                                     19.95]},
-             {"Hash slice list",
-              "$.store.book[0]['category','author']", [<<"reference">>,
-                                                       <<"Nigel Rees">>]},
+     {"Name refine bracket plus idx",
+      "$.store['book'][0].category", [<<"reference">>]},
+     {"Array idx",
+      "$.store.book[0].category", [<<"reference">>]},
+     {"Asterisk array",
+      "$.store.book[*].category", [<<"reference">>,
+                                   <<"fiction">>,
+                                   <<"fiction">>,
+                                   <<"fiction">>]},
+     {"Asterisk hash",
+      "$.store.bicycle[*]", [<<"red">>,
+                             19.95]},
+     {"Hash slice list",
+      "$.store.book[0]['category','author']", [<<"reference">>,
+                                               <<"Nigel Rees">>]},
 
-             {"Bin-eval array literal-string expr",
-              "$.store[?('ok')].color", [<<"red">>]},
-             {"Bin-eval array literal-empty-string expr",
-              "$.store[?('')].color", []},
-             {"Bin-eval array literal-integer expr",
-              "$.store[?(1)].color", [<<"red">>]},
-             {"Bin-eval array literal-zero expr",
-              "$.store[?(0)].color", []},
-             %% {"Bin-eval array literal-boolean-true expr",
-             %%  "$.store[?(true)].color", [<<"red">>]},
-             %% {"Bin-eval array literal-boolean-false expr",
-             %%  "$.store[?(false)].color", []},
-             {"Bin-eval array subst-self expr",
-              "$.store[?(@)].color", [<<"red">>]},
-             {"Bin-eval array function call",
-              "$.store[?(my_fun())].color", [<<"red">>],
-              [{<<"my_fun">>, fun(_, []) -> true end}]},
-             {"Bin-eval array function call",
-              "$.store[?(my_fun())].color", [],
-              [{<<"my_fun">>, fun(_, []) -> false end}]},
-             {"Bin-eval array function call with args",
-              "$.store[?(my_fun('a1', 42))].color", [],
-              [{<<"my_fun">>, fun(_, [<<"a1">>, 42]) -> false end}]},
+     {"Bin-eval array literal-string expr",
+      "$.store[?('ok')].color", [<<"red">>]},
+     {"Bin-eval array literal-empty-string expr",
+      "$.store[?('')].color", []},
+     {"Bin-eval array literal-integer expr",
+      "$.store[?(1)].color", [<<"red">>]},
+     {"Bin-eval array literal-zero expr",
+      "$.store[?(0)].color", []},
+     %% {"Bin-eval array literal-boolean-true expr",
+     %%  "$.store[?(true)].color", [<<"red">>]},
+     %% {"Bin-eval array literal-boolean-false expr",
+     %%  "$.store[?(false)].color", []},
+     {"Bin-eval array subst-self expr",
+      "$.store[?(@)].color", [<<"red">>]},
+     {"Bin-eval array function call",
+      "$.store[?(my_fun())].color", [<<"red">>],
+      [{<<"my_fun">>, fun(_, []) -> true end}]},
+     {"Bin-eval array function call",
+      "$.store[?(my_fun())].color", [],
+      [{<<"my_fun">>, fun(_, []) -> false end}]},
+     {"Bin-eval array function call with args",
+      "$.store[?(my_fun('a1', 42))].color", [],
+      [{<<"my_fun">>, fun(_, [<<"a1">>, 42]) -> false end}]},
 
-             {"Bin-eval array function call",
-              "$.store.book[?(filter_reference())].author", [<<"Nigel Rees">>],
-              [{<<"filter_reference">>,
-                fun({{Pairs}, _Doc}, []) ->
-                        case proplists:get_value(<<"category">>, Pairs) of
-                            <<"reference">> -> true;
-                            _ -> false
-                        end
-                end}]},
+     {"Bin-eval array function call",
+      "$.store.book[?(filter_reference())].author", [<<"Nigel Rees">>],
+      [{<<"filter_reference">>,
+        fun({Hash, _Doc}, []) ->
+                Val = case Hash of
+                          {KV} ->
+                              proplists:get_value(<<"category">>, KV);
+                          Map ->
+                              maps:get(<<"category">>, Map, nil)
+                      end,
+                Val == <<"reference">>
+        end}]},
 
-             {"Script simple path",
-              "$.store.book[?(@.isbn)].price", [8.99, 22.99]},
-             {"Script greater than expr",
-              "$.store.book[?(@.price > 9)].isbn", [<<"0-395-19395-8">>]},
-             {"Script equality expr",
-              "$.store.book[?('reference' == @.category)].author",
-              [<<"Nigel Rees">>]},
-             {"Script inequality expr",
-              "$.store.book[?(@.category != 'fiction')].author",
-              [<<"Nigel Rees">>]},
-             {"Script comparing constants",
-              "$.store.book[?('asdf'=='asdf')].category",
-              [<<"reference">>, <<"fiction">>, <<"fiction">>, <<"fiction">>]},
-             {"Script comparing paths",
-              "$.store.book[?(@.category == @.category)].category",
-              [<<"reference">>, <<"fiction">>, <<"fiction">>, <<"fiction">>]},
+     {"Script simple path",
+      "$.store.book[?(@.isbn)].price", [8.99, 22.99]},
+     {"Script greater than expr",
+      "$.store.book[?(@.price > 9)].isbn", [<<"0-395-19395-8">>]},
+     {"Script equality expr",
+      "$.store.book[?('reference' == @.category)].author",
+      [<<"Nigel Rees">>]},
+     {"Script inequality expr",
+      "$.store.book[?(@.category != 'fiction')].author",
+      [<<"Nigel Rees">>]},
+     {"Script comparing constants",
+      "$.store.book[?('asdf'=='asdf')].category",
+      [<<"reference">>, <<"fiction">>, <<"fiction">>, <<"fiction">>]},
+     {"Script comparing paths",
+      "$.store.book[?(@.category == @.category)].category",
+      [<<"reference">>, <<"fiction">>, <<"fiction">>, <<"fiction">>]},
 
-             {"Index-eval on array",
-              "$.store.book[(1)].author", [<<"Evelyn Waugh">>]},
-             {"Index-eval on hash",
-              "$.store.book[(1)][('author')]", [<<"Evelyn Waugh">>]},
-             {"Capitals should work in paths",
-              "$.store.LOLs.CHEEZBURG", [<<"no">>]},
-             {"Capitals should work in paths",
-              "$.store.LOLs.Cats", [<<"yes">>]}
+     {"Index-eval on array",
+      "$.store.book[(1)].author", [<<"Evelyn Waugh">>]},
+     {"Index-eval on hash",
+      "$.store.book[(1)][('author')]", [<<"Evelyn Waugh">>]},
+     {"Capitals should work in paths",
+      "$.store.LOLs.CHEEZBURG", [<<"no">>]},
+     {"Capitals should work in paths",
+      "$.store.LOLs.Cats", [<<"yes">>]}
+    ].
 
-            ],
+jiffy_test_() ->
+    Doc = get_doc([]),
+    Tests = cases(),
+    do_test(Doc, Tests).
+
+maps_test_() ->
+    Doc = get_doc([return_maps]),
+    Tests = cases(),
+    do_test(Doc, Tests).
+
+do_test(Doc, Pairs) ->
     lists:map(
       fun({Name, Expr, Expected}) ->
               {Name,
@@ -126,36 +138,8 @@ all_test_() ->
                        %% io:format(user, "~p~n~p~n~n", [Expr, Result]),
                        ?assertEqual(Expected, Result)
                end}
-      end,  Pairs).
+      end, Pairs).
 
-
-get_doc() ->
-    %% {ok, Bin} = file:read_file("../test/doc.json"),
-    %% io:format(user, "~p~n", [jiffy:decode(Bin)]),
-    %% jiffy:decode(Bin)
-    {[{<<"store">>,
-          {[{<<"book">>,
-                [{[{<<"category">>,<<"reference">>},
-                      {<<"author">>,<<"Nigel Rees">>},
-                      {<<"title">>,<<"Sayings of the Century">>},
-                      {<<"price">>,8.95}]},
-                  {[{<<"category">>,<<"fiction">>},
-                      {<<"author">>,<<"Evelyn Waugh">>},
-                      {<<"title">>,<<"Sword of Honour">>},
-                      {<<"price">>,12.99}]},
-                  {[{<<"category">>,<<"fiction">>},
-                      {<<"author">>,<<"Herman Melville">>},
-                      {<<"title">>,<<"Moby Dick">>},
-                      {<<"isbn">>,<<"0-553-21311-3">>},
-                      {<<"price">>,8.99}]},
-                  {[{<<"category">>,<<"fiction">>},
-                      {<<"author">>,<<"J. R. R. Tolkien">>},
-                      {<<"title">>,<<"The Lord of the Rings">>},
-                      {<<"isbn">>,<<"0-395-19395-8">>},
-                      {<<"price">>,22.99}]}]},
-              {<<"bicycle">>,
-                {[{<<"color">>,<<"red">>},{<<"price">>,19.95}]}},
-              {<<"LOLs">>,
-                {[{<<"Cats">>,<<"yes">>},
-                    {<<"Dogs">>,<<"yes">>},
-                    {<<"CHEEZBURG">>,<<"no">>}]}}]}}]}.
+get_doc(Opts) ->
+    {ok, Bin} = file:read_file("./test/doc.json"),
+    jiffy:decode(Bin, Opts).


### PR DESCRIPTION
So, it now can search through map json representation `#{<<"my_key1">> => 1, <<"my_key2">> => <<"ok">>}`.
Also, `ejsonpath:execute/3` 3rd argument (custom functions) can be a map now.