### PR TITLE
Fix bug with integer keys

### DIFF
--- a/src/ejsonpath_eval.erl
+++ b/src/ejsonpath_eval.erl
@@ -52,6 +52,12 @@ apply_eval({key, '*'}, #argument{type = array, node = Node} = Arg, Ctx) ->
     ?EJSONPATH_LOG({key, array, '*'}),
     Idxs = lists:seq(0, erlang:length(Node)-1),
     apply_eval({access_list, Idxs}, Arg, Ctx);
+apply_eval({key, Key}, #argument{type = array, node = Node} = Arg, Ctx) when is_integer(Key) ->
+    ?EJSONPATH_LOG({key, array, Key}),
+    apply_eval({access_list, [Key]}, Arg, Ctx);
+apply_eval({key, Key}, #argument{type = hash} = Arg, Ctx) when is_integer(Key) -> 
+    ?EJSONPATH_LOG({key, Key}),
+    apply_eval({access_list, [integer_to_binary(Key)]}, Arg, Ctx);
 apply_eval({key, Key}, #argument{type = hash} = Arg, Ctx) -> 
     ?EJSONPATH_LOG({key, Key}),
     apply_eval({access_list, [Key]}, Arg, Ctx);

--- a/src/ejsonpath_parse.yrl
+++ b/src/ejsonpath_parse.yrl
@@ -105,7 +105,7 @@ predicate -> '[' slice ']'          : {predicate, '$2'}.
 predicate -> '[' '*' ']'            : {predicate, {key, value('$2')}}.
 
 key_predicate -> key : {predicate, {key, value('$1')}}.
-key_predicate -> int : {predicate, {key, integer_to_binary(value('$1'))}}.
+key_predicate -> int : {predicate, {key, value('$1')}}.
 key_predicate -> '*' : {predicate, {key, value('$1')}}.
 
 %% ?(a=="b")

--- a/src/ejsonpath_parse.yrl
+++ b/src/ejsonpath_parse.yrl
@@ -105,6 +105,7 @@ predicate -> '[' slice ']'          : {predicate, '$2'}.
 predicate -> '[' '*' ']'            : {predicate, {key, value('$2')}}.
 
 key_predicate -> key : {predicate, {key, value('$1')}}.
+key_predicate -> int : {predicate, {key, integer_to_binary(value('$1'))}}.
 key_predicate -> '*' : {predicate, {key, value('$1')}}.
 
 %% ?(a=="b")

--- a/src/ejsonpath_transform.erl
+++ b/src/ejsonpath_transform.erl
@@ -47,6 +47,16 @@ transform_step([{child, {predicate, {key, '*'}}} | Rest], #argument{type = array
     ?EJSONPATH_LOG({enter, key, '*', _Path}),
     Idxs = lists:seq(0, erlang:length(Node)-1),
     transform_step([{child, {predicate, {access_list, Idxs}}}] ++ Rest, Arg, Ctx);
+transform_step([{child, {predicate, {key, Key}}} | Rest],
+               #argument{type = array, node = _Node, path = _Path} = Arg, Ctx) when is_integer(Key) ->
+    ?EJSONPATH_LOG({enter, key, Key, _Path}),
+    transform_step([{child, {predicate, {access_list, [Key]}}}] ++ Rest, Arg, Ctx);
+
+transform_step([{child, {predicate, {key, Key}}} | Rest], #argument{type = hash, path = Path} = Arg, Ctx) when is_integer(Key) ->
+    ?EJSONPATH_LOG({enter, key, Key, Path}),
+    apply_transform([integer_to_binary(Key)], Arg, fun(_, Value) -> 
+        transform_step(Rest, argument(Value, Path, integer_to_binary(Key)), Ctx)
+    end, Ctx, Rest /= []);
 
 % {key, Key}
 transform_step([{child, {predicate, {key, Key}}} | Rest], #argument{type = hash, path = Path} = Arg, Ctx) ->

--- a/test/doc.json
+++ b/test/doc.json
@@ -1,41 +1,47 @@
-{ "store": {
-    "book": [ 
-      { "id" : 0,
-        "category": "reference",
-        "author": "Nigel Rees",
-        "title": "Sayings of the Century",
-        "price": 8.95
-      },
-      { "id" : 1,
-        "category": "fiction",
-        "author": "Evelyn Waugh",
-        "title": "Sword of Honour",
-        "price": 12.99
-      },
-      { "id" : 2,
-        "category": "fiction",
-        "author": "Herman Melville",
-        "title": "Moby Dick",
-        "isbn": "0-553-21311-3",
-        "price": 8.99
-      },
-      { "id" : 3,
-        "category": "fiction",
-        "author": "J. R. R. Tolkien",
-        "title": "The Lord of the Rings",
-        "isbn": "0-395-19395-8",
-        "price": 22.99
-      }
-    ],
-    "bicycle": {
-      "color": "red",
-      "price": 19.95
-    },
-    "LOLs": {
-      "Cats": "yes",
-      "Dogs": "yes",
-      "CHEEZBURG": "no"
+{
+    "last_id": 3,
+    "store": {
+        "3": "an-integer-key",
+        "LOLs": {
+            "CHEEZBURG": "no",
+            "Cats": "yes",
+            "Dogs": "yes"
+        },
+        "bicycle": {
+            "color": "red",
+            "price": 19.95
+        },
+        "book": [
+            {
+                "author": "Nigel Rees",
+                "category": "reference",
+                "id": 0,
+                "price": 8.95,
+                "title": "Sayings of the Century"
+            },
+            {
+                "author": "Evelyn Waugh",
+                "category": "fiction",
+                "id": 1,
+                "price": 12.99,
+                "title": "Sword of Honour"
+            },
+            {
+                "author": "Herman Melville",
+                "category": "fiction",
+                "id": 2,
+                "isbn": "0-553-21311-3",
+                "price": 8.99,
+                "title": "Moby Dick"
+            },
+            {
+                "author": "J. R. R. Tolkien",
+                "category": "fiction",
+                "id": 3,
+                "isbn": "0-395-19395-8",
+                "price": 22.99,
+                "title": "The Lord of the Rings"
+            }
+        ]
     }
-  },
-"last_id" : 3
 }

--- a/test/ejsonpath_eval_tests.erl
+++ b/test/ejsonpath_eval_tests.erl
@@ -63,6 +63,9 @@ key_access_test() ->
 
     ?assertEqual({[<<"red">>], ["$['store']['bicycle']['color']"]}, ejsonpath_eval:eval(?ast("$.store.bicycle.color"), get_doc(), #{}, [])),
 
+    ?assertEqual({[<<"reference">>], ["$['store']['book'][0]['category']"]},
+                 ejsonpath_eval:eval(?ast("$.store.book.0.category"), get_doc(), #{}, [])),
+
     ?assertEqual({[<<"an-integer-key">>], ["$['store']['3']"]}, ejsonpath_eval:eval(?ast("$.store.3"), get_doc(), #{}, [])),
     
     ok.

--- a/test/ejsonpath_eval_tests.erl
+++ b/test/ejsonpath_eval_tests.erl
@@ -62,6 +62,8 @@ key_access_test() ->
     ?assertEqual({[maps:get(<<"store">>, get_doc())], ["$['store']"]}, ejsonpath_eval:eval(?ast("$.store"), get_doc(), #{}, [])),
 
     ?assertEqual({[<<"red">>], ["$['store']['bicycle']['color']"]}, ejsonpath_eval:eval(?ast("$.store.bicycle.color"), get_doc(), #{}, [])),
+
+    ?assertEqual({[<<"an-integer-key">>], ["$['store']['3']"]}, ejsonpath_eval:eval(?ast("$.store.3"), get_doc(), #{}, [])),
     
     ok.
 

--- a/test/ejsonpath_transform_tests.erl
+++ b/test/ejsonpath_transform_tests.erl
@@ -40,6 +40,12 @@ key_access_test() ->
 
     ?assertEqual({#{<<"a">> => #{<<"a">> => y}},  ["$['a']['a']"]}, 
         ejsonpath_transform:transform(?ast("$.a.a"), #{<<"a">> => #{<<"a">> => x}}, fun ({match, #{node := x}}) -> {ok, y} end, #{}, [])),
+
+    ?assertEqual({#{<<"3">> => y},  ["$['3']"]}, 
+        ejsonpath_transform:transform(?ast("$.3"), #{<<"3">> => x}, fun ({match, #{node := x}}) -> 
+            {ok, y}
+        end, #{}, [])),
+
     ok.
 
 index_access_test() ->
@@ -51,6 +57,8 @@ index_access_test() ->
     ?assertError(not_found,
         ejsonpath_transform:transform(?ast("$.a[3]"), #{<<"a">> => [x, y, z]}, fun (_) -> {ok, y} end, #{}, [])),
     
+    ?assertEqual({#{<<"a">> => [y, y, z]},  ["$['a'][0]"]}, 
+        ejsonpath_transform:transform(?ast("$.a.0"), #{<<"a">> => [x, y, z]}, fun ({match, #{node := x}}) -> {ok, y} end, #{}, [])),
     ok.
 access_list_test() ->
     ?assertEqual(


### PR DESCRIPTION
Previously, a query such as `$.3` would fail. This PR fixes this problem.

This also fixes one of the issues in #6.